### PR TITLE
chore: enable mathlib linter

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -3,9 +3,11 @@ defaultTargets = ["Statlib"]
 version = "0.1.0"
 keywords = ["probability", "statistics", "lean"]
 packagesDir = ".lake/packages"
+lintDriver = "batteries/runLinter"
 
 [leanOptions]
 autoImplicit = true
+weak.linter.mathlibStandardSet = true
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
This PR enables the Batteries lint driver and turns on the weak mathlib standard linter set in `lakefile.toml`, so Statlib uses the same linting setup expected for mathlib-style Lean development.

Created with the help of codex.